### PR TITLE
Fix: Improve accessibility filter logic in location service

### DIFF
--- a/api/src/services/location-service.ts
+++ b/api/src/services/location-service.ts
@@ -71,15 +71,15 @@ const buildLocationWhereClause = (filters: LocationFilters) => {
 
   if (filters.accessibility) {
     const questionIds = filters.accessibility.split(',').map((id) => id.trim());
-    where.answer = {
-      some: {
-        questionId: {
-          in: questionIds,
+    where.AND = questionIds.map((questionId) => ({
+      answer: {
+        some: {
+          questionId,
+          answer: 1,
+          deletedAt: null,
         },
-        answer: 1,
-        deletedAt: null,
       },
-    };
+    }));
   }
 
   return where;


### PR DESCRIPTION
## Overview
This PR fixes the accessibility filtering logic in the location service to ensure more accurate location filtering results.

## Changes Made
- **Replaced single 'some' clause with multiple AND conditions** for accessibility questions
- **Enhanced filtering logic** to require ALL specified accessibility criteria to be met rather than just ANY one of them
- **Maintained proper null checking** for deletedAt field to ensure data integrity

## Problem Solved
The previous implementation used a single 'some' clause which would return locations that satisfied ANY of the accessibility criteria. This has been changed to use multiple AND conditions that ensure ALL specified accessibility question IDs must be satisfied (with answer: 1).

## Technical Details
- Changed from  with  clause to  with mapped individual question conditions
- Each accessibility question now requires  and 
- This provides more precise filtering for location searches with multiple accessibility requirements

## Testing
- [ ] Verify that locations with ALL specified accessibility features are returned
- [ ] Confirm that locations missing any required accessibility feature are filtered out
- [ ] Test with various combinations of accessibility question IDs

## Impact
This change improves the accuracy of location search results when accessibility filters are applied, ensuring users get locations that truly meet all their accessibility needs.